### PR TITLE
Added average time to trend and graphs of likes vs. trending date

### DIFF
--- a/client/src/pages/Country/Country.tsx
+++ b/client/src/pages/Country/Country.tsx
@@ -158,6 +158,24 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   y: video.comment_count,
                 }))}
             />
+            <div></div>
+            <h3>Number of Likes vs Trending Date</h3>
+            <LineGraph
+              results={genResults
+                .map((video) => ({
+                  ...video,
+                  pub_date: video.pub_date.replace("-", "/"),
+                }))
+                .sort(
+                  (a, b) =>
+                    new Date(a.trend_date).getTime() -
+                    new Date(b.trend_date).getTime()
+                )
+                .map((video) => ({
+                  x: video.trend_date,
+                  y: video.likes,
+                }))}
+            />
           </>
         )}
       </DropDown>

--- a/client/src/pages/Country/Country.tsx
+++ b/client/src/pages/Country/Country.tsx
@@ -188,14 +188,33 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
         />
 
         {catResults.length > 0 ? (
-          <div className="resultContainer">
+          <>
+            <h3>Number of Likes vs Trending Date</h3>
+            <LineGraph
+              results={catResults
+                .map((video) => ({
+                  ...video,
+                  pub_date: video.pub_date.replace("-", "/"),
+                }))
+                .sort(
+                  (a, b) =>
+                    new Date(a.trend_date).getTime() -
+                    new Date(b.trend_date).getTime()
+                )
+                .map((video) => ({
+                  x: video.trend_date,
+                  y: video.likes,
+                }))}
+            />
+            <div className="resultContainer">
             {catResults.map((result, index) => (
               <div key={index}>
                 <p>{result?.title}</p>
                 <hr style={{ width: "30%" }} />
               </div>
             ))}
-          </div>
+            </div>
+          </> 
         ) : (
           <p>No videos for provided category.</p>
         )}

--- a/client/src/pages/Country/Country.tsx
+++ b/client/src/pages/Country/Country.tsx
@@ -34,6 +34,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
       { name: "Average Likes", short: "avg_likes", value: null },
       { name: "Average Dislikes", short: "avg_dislikes", value: null },
       { name: "Average Views", short: "avg_views", value: null },
+      { name: "Average Time to Trend", short: "avg_time_to_trend", value: null },
     ].sort((a, b) => a.name.localeCompare(b.name, "en"))
   );
 

--- a/server/database/database.js
+++ b/server/database/database.js
@@ -70,6 +70,7 @@ const parseData = (err, data) => {
   let num_dislikes = 0;
   let num_views = 0;
   let num_min = 0;
+  let num_to_trend = 0;
 
   let video_count = 0;
 
@@ -109,6 +110,7 @@ const parseData = (err, data) => {
         num_dislikes = num_dislikes + parseInt(values.dislikes)
         num_views = num_views + parseInt(values.views)
         num_min = num_min + values.pub_time_min
+        num_to_trend = num_to_trend + parseInt(values.pub_to_trend)
 
         video_count = video_count + 1
 
@@ -133,6 +135,8 @@ const parseData = (err, data) => {
     finalArr.avg_time_of_day = (Math.round(((num_min / video_count) / 60) * 10) / 10).toString().split('.') // rounded to 1 decimal place
     finalArr.avg_time_of_day[1] = (parseInt(finalArr.avg_time_of_day[1]) / 10 * 60).toString() // fraction of hour to minutes
     finalArr.avg_time_of_day = finalArr.avg_time_of_day.join(':')
+
+    finalArr.avg_time_to_trend = `${Math.floor(num_to_trend / video_count).toString()} days`;
 
     finalArr.videos.push(values);
     values = {};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "server",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Overview
- Added average days to trend as a metric under the general metrics dropdown.
- Added a graph of likes vs. trending date under general metrics.
- Added a graph of likes vs. trending date under query metrics.

## Materials
- #50 (adds graph to query metrics; only for likes vs. trending date rn)

## Pictures
<img width="200" alt="Screen Shot 2022-05-05 at 7 20 17 PM" src="https://user-images.githubusercontent.com/24843819/167056102-126a0f2e-c14b-4889-adf4-6034862472b2.png">
<img width="831" alt="Screen Shot 2022-05-05 at 7 22 55 PM" src="https://user-images.githubusercontent.com/24843819/167056394-6a396c92-27db-410f-8442-c7a4ef5afb8c.png">
<img width="819" alt="Screen Shot 2022-05-05 at 7 23 25 PM" src="https://user-images.githubusercontent.com/24843819/167056443-9c72d19a-810a-4d64-9ae2-0847a67a1ffe.png">


## Manual Testing Guide
Click on the General Metrics tab, should see "Average time to trend" with the number of days below.
Click on the General Metrics tab, should see a graph of "Likes vs. trending date".
Click on the Query Metrics tab, should see a graph of "Likes vs. trending date".

Pull requests should receive approval before merge.
