### PR TITLE
Jchan419 fix pie chart overlap

### DIFF
--- a/client/src/components/Home/PubForm/PieChart/PieChart.tsx
+++ b/client/src/components/Home/PubForm/PieChart/PieChart.tsx
@@ -12,7 +12,7 @@ export type PieChartProps = {
         <ResponsivePie
             data={results}
             sortByValue ={true}
-            margin={{ top: 20, right: 20, bottom: 40, left: 450 }}
+            margin={{ top: 20, right: 20, bottom: 40, left: 500 }}
             colors={{ scheme: 'set2' }}
             innerRadius={0.5}
             padAngle={0.7}

--- a/client/src/components/Home/PubForm/PieChart/PieChart.tsx
+++ b/client/src/components/Home/PubForm/PieChart/PieChart.tsx
@@ -1,38 +1,6 @@
 import * as React from "react";
 import { ResponsivePie } from '@nivo/pie'
 
-// const data = [
-//   {
-//     "id": "lisp",
-//     "label": "lisp",
-//     "value": 168,
-//     "color": "hsl(39, 70%, 50%)"
-//   },
-//   {
-//     "id": "scala",
-//     "label": "scala",
-//     "value": 262,
-//     "color": "hsl(187, 70%, 50%)"
-//   },
-//   {
-//     "id": "stylus",
-//     "label": "stylus",
-//     "value": 410,
-//     "color": "hsl(302, 70%, 50%)"
-//   },
-//   {
-//     "id": "python",
-//     "label": "python",
-//     "value": 368,
-//     "color": "hsl(348, 70%, 50%)"
-//   },
-//   {
-//     "id": "make",
-//     "label": "make",
-//     "value": 599,
-//     "color": "hsl(76, 70%, 50%)"
-//   }
-// ]
 // Formatting and code from the nivo chart website https://nivo.rocks/pie/
 export type PieChartProps = {
     results: any[];
@@ -40,10 +8,12 @@ export type PieChartProps = {
   
   export const PieChart: React.FC<PieChartProps> = ({ results }) => {
     return (
-      <div style={{ height: 420, maxWidth: "100%" }}>
+      <div style={{ height: 420, maxWidth: "100%"}}>
         <ResponsivePie
             data={results}
-            margin={{ top: 20, right: 20, bottom: 40, left: 800 }}
+            sortByValue ={true}
+            margin={{ top: 20, right: 20, bottom: 40, left: 450 }}
+            colors={{ scheme: 'set2' }}
             innerRadius={0.5}
             padAngle={0.7}
             cornerRadius={3}
@@ -61,7 +31,7 @@ export type PieChartProps = {
             arcLinkLabelsSkipAngle={10}
             arcLinkLabelsTextColor="#333333"
             arcLinkLabelsThickness={2}
-            arcLinkLabelsColor={{ from: 'color' }}
+            arcLinkLabelsColor="black"
             arcLabelsSkipAngle={10}
             arcLabelsTextColor={{
                 from: 'color',

--- a/client/src/pages/Home/Home.css
+++ b/client/src/pages/Home/Home.css
@@ -35,5 +35,5 @@
 
 .chart{
     margin-top: -100px;
-    margin-left: 250px;
+    margin-left: 20%;
 }

--- a/client/src/pages/Home/Home.css
+++ b/client/src/pages/Home/Home.css
@@ -34,6 +34,6 @@
 }
 
 .chart{
-
     margin-top: -100px;
+    margin-left: 250px;
 }

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -69,11 +69,11 @@ export const Home = () => {
             transition={{ type: "spring", duration: 1 }}
             className="chart"
           >
-            <PieChart
-              results={
-                numCountryVideos
-              }
-            />
+          <PieChart
+            results={
+              numCountryVideos
+            }
+          />
           </motion.div>
         </>
       ) : (

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -69,11 +69,11 @@ export const Home = () => {
             transition={{ type: "spring", duration: 1 }}
             className="chart"
           >
-          <PieChart
-            results={
-              numCountryVideos
-            }
-          />
+            <PieChart
+              results={
+                numCountryVideos
+              }
+            />
           </motion.div>
         </>
       ) : (


### PR DESCRIPTION
## Overview
PieChart.tsx
* Removed testing data
* Updated left margin from 800 to 500
* Updated the pie chart to sort by size of the slices
* Changed the color scheme of the pie chart from "nivo" to "set2"
* Changed the label arc color to "black"

Home.css
* Added a margin to the left of the "chart" className of 20%


## Materials
- #57 


## Pictures
![image](https://user-images.githubusercontent.com/42459094/167568928-734b6e32-e565-4cde-ae81-e5e2f952c7d6.png)
![CS180_Roald_Button](https://user-images.githubusercontent.com/42459094/167581604-78850d27-520f-42b8-968a-2c2a217c8b49.gif)

## Manual Testing Guide
 - Navigate to the home page
 - Click the "Enter Custom Video Data" button
 -  You should see the screen switch to a page where you can fill out a form
