### PR TITLE
Removed duplicate X values and averaged their Y values from graphs

### DIFF
--- a/client/src/components/Country/LineGraph/LineGraph.tsx
+++ b/client/src/components/Country/LineGraph/LineGraph.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { ResponsiveLine } from "@nivo/line";
+import { sortAndDeduplicateDiagnostics } from "typescript";
 
 export type Props = {
   results: any[];
@@ -19,6 +20,15 @@ export const LineGraph: React.FC<Props> = ({ results, color, title }) => {
     default:
       scrollWidth.width = 1850;
   }
+
+  for(let i = 0; i < results.length-1; i++){
+    if(results[i].x === results[i+1].x){
+      results[i].y = ((parseInt(results[i].y) + parseInt(results[i+1].y))/2).toString();
+      results.splice(i+1, 1);
+      i--;
+    }
+  }
+
   return (
     <div style={{ height: 420, maxWidth: "100%", overflow: 'scroll'}}>
       <ResponsiveLine {... scrollWidth}


### PR DESCRIPTION
## Overview
LineGraph.tsx
* If duplicate x values of a graph are found, average their y values and delete the duplicate

## Materials
- #47 

## Pictures
15 data points
![image](https://user-images.githubusercontent.com/42459094/168019063-a31ccdbc-c24b-4022-a5e1-5bdc46a3015b.png)
Max data points 
![image](https://user-images.githubusercontent.com/42459094/168018956-4b97848b-5cb6-41d0-a3f7-202d05d1752d.png)


## Manual Testing Guide
Testing the first 15 points
- Click on a country
- See under General Metrics the graphs have no holes

Testing all possible points on a graph
 - Go to line 60 in Countries.tsx and remove ".splice(0, 15)"
 - Save
 - Type and enter both "npm intall" and "npm start" in that order in the server and client folders
 - Navigate to a Country on localhost:3000
 - Under General Metrics, there should be no holes in the graphs

Testing User Data
 - Go to home page and enter in a user date that one of the graphs contains
 - Navigate back to the country and into "Experimental Metrics"
 - Notice how there are no holes in the graph shown
