### PR TITLE
Added scaling to Line Graphs 

### DIFF
--- a/client/src/components/Country/LineGraph/LineGraph.tsx
+++ b/client/src/components/Country/LineGraph/LineGraph.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { ResponsiveLine } from "@nivo/line";
-import { forEachLeadingCommentRange } from "typescript";
 
 export type Props = {
   results: any[];

--- a/client/src/components/Country/LineGraph/LineGraph.tsx
+++ b/client/src/components/Country/LineGraph/LineGraph.tsx
@@ -11,24 +11,37 @@ const scrollWidth = {
 }
 
 export const LineGraph: React.FC<Props> = ({ results, color }) => {  
+  for(let i = 0; i < results.length-1; i++){
+    if(results[i].x === results[i+1].x){
+      results[i].y = ((parseInt(results[i].y) + parseInt(results[i+1].y))/2).toString();
+      results.splice(i+1, 1);
+      i--;
+    }
+  }
+
   if (results.length <= 15){
     scrollWidth.width = 1750
   }
-  else if (results.length < 51){
-    scrollWidth.width = 2000
+  else if (results.length <= 50){
+    scrollWidth.width = 4000
   }
-  else if (results.length < 201){
-    scrollWidth.width = 7000
+  else if (results.length <= 100){
+    scrollWidth.width = 6000
   }
-  else if (results.length < 1000){
-    scrollWidth.width = 14000
+  else if (results.length <= 200){
+    scrollWidth.width = 13500
   }
-  else if (results.length < 2000){
-    scrollWidth.width = 17000
+  else if (results.length <= 1000){
+    scrollWidth.width = 21000
+  }
+  else if (results.length <= 2000){
+    scrollWidth.width = 22000
   }
   else{
-    scrollWidth.width = 22000
+    scrollWidth.width = 25000
   } 
+
+
   return (
     <div style={{ height: 420, maxWidth: "100%", overflow: 'scroll'}}>
       <ResponsiveLine {... scrollWidth}

--- a/client/src/components/Country/LineGraph/LineGraph.tsx
+++ b/client/src/components/Country/LineGraph/LineGraph.tsx
@@ -1,24 +1,36 @@
 import * as React from "react";
 import { ResponsiveLine } from "@nivo/line";
+import { forEachLeadingCommentRange } from "typescript";
 
 export type Props = {
   results: any[];
   color?: boolean;
-  title: string;
+  size: number;
 };
 
 const scrollWidth = {
-  width: 10000
+  width: 20000
 }
 
-export const LineGraph: React.FC<Props> = ({ results, color, title }) => {
-  switch (title){
-    case 'Query':
-      scrollWidth.width = 20000;
-      break;
-    default:
-      scrollWidth.width = 1850;
+export const LineGraph: React.FC<Props> = ({ results, color, size }) => {
+  if (size <= 15){
+    scrollWidth.width = 1750
   }
+  else if (size < 51){
+    scrollWidth.width = 2000
+  }
+  else if (size < 201){
+    scrollWidth.width = 7000
+  }
+  else if (size < 1000){
+    scrollWidth.width = 14000
+  }
+  else if (size < 2000){
+    scrollWidth.width = 17000
+  }
+  else{
+    scrollWidth.width = 22000
+  } 
   return (
     <div style={{ height: 420, maxWidth: "100%", overflow: 'scroll'}}>
       <ResponsiveLine {... scrollWidth}

--- a/client/src/components/Country/LineGraph/LineGraph.tsx
+++ b/client/src/components/Country/LineGraph/LineGraph.tsx
@@ -1,31 +1,29 @@
 import * as React from "react";
 import { ResponsiveLine } from "@nivo/line";
-import { forEachLeadingCommentRange } from "typescript";
 
 export type Props = {
   results: any[];
   color?: boolean;
-  size: number;
 };
 
 const scrollWidth = {
   width: 20000
 }
 
-export const LineGraph: React.FC<Props> = ({ results, color, size }) => {
-  if (size <= 15){
+export const LineGraph: React.FC<Props> = ({ results, color }) => {  
+  if (results.length <= 15){
     scrollWidth.width = 1750
   }
-  else if (size < 51){
+  else if (results.length < 51){
     scrollWidth.width = 2000
   }
-  else if (size < 201){
+  else if (results.length < 201){
     scrollWidth.width = 7000
   }
-  else if (size < 1000){
+  else if (results.length < 1000){
     scrollWidth.width = 14000
   }
-  else if (size < 2000){
+  else if (results.length < 2000){
     scrollWidth.width = 17000
   }
   else{

--- a/client/src/pages/Country/Country.tsx
+++ b/client/src/pages/Country/Country.tsx
@@ -57,7 +57,8 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
     axios
       .get(`${BACKEND_URL}/countries/${country}`)
       .then((res) => {
-        setGenResults(res.data.videos.splice(0, 15));
+        setGenResults(res.data.videos);
+
         setAvgResults((prev) =>
           prev
             .map((avg) => ({
@@ -143,7 +144,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.pub_date,
                   y: video.pub_to_trend,
                 }))}
-                title = {'Gen'}
+                size = {genResults.length}
             />
             <div></div>
             <h3>Number of Comments vs Trending Date</h3>
@@ -161,7 +162,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.trend_date,
                   y: video.comment_count,
                 }))}
-                title = {'Gen'}
+                size = {genResults.length}
             />
             <div></div>
             <h3>Number of Likes vs Trending Date</h3>
@@ -179,7 +180,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.trend_date,
                   y: video.likes,
                 }))}
-                title = {'Gen'}
+                size = {genResults.length}
             />
           </>
         )}
@@ -205,7 +206,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.pub_date,
                   y: video.pub_to_trend,
                 }))}
-                title = {'Query'} 
+                size = {catResults.length}
               /><div></div>
             <h3>Number of Comments vs Trending Date</h3>
              <LineGraph
@@ -221,7 +222,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.trend_date,
                   y: video.comment_count,
                 }))}
-                title = {'Query'}
+                size = {catResults.length}
                 /><div></div>
             <h3>Number of Likes vs Trending Date</h3>
             <LineGraph
@@ -238,7 +239,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.trend_date,
                   y: video.likes,
                 }))}
-                title = {'Query'}
+                size = {catResults.length}
             />
           </> 
         ) : (
@@ -264,11 +265,11 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                 )
                 .map((video) => ({
                   x: video.pub_date,
-                  y: video.pub_to_trend,
+                  y: parseInt(video.pub_to_trend),
                   custom: video.video_id.length < 1,
                 }))}
-                title = {"Experimental"}
-              color
+                size = {expResults.length}
+                color
             />
           </>
         )}

--- a/client/src/pages/Country/Country.tsx
+++ b/client/src/pages/Country/Country.tsx
@@ -268,7 +268,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   y: parseInt(video.pub_to_trend),
                   custom: video.video_id.length < 1,
                 }))}
-                size = {expResults.length}
+                size = {genResults.length}
                 color
             />
           </>

--- a/client/src/pages/Country/Country.tsx
+++ b/client/src/pages/Country/Country.tsx
@@ -144,7 +144,6 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.pub_date,
                   y: video.pub_to_trend,
                 }))}
-                size = {genResults.length}
             />
             <div></div>
             <h3>Number of Comments vs Trending Date</h3>
@@ -162,7 +161,6 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.trend_date,
                   y: video.comment_count,
                 }))}
-                size = {genResults.length}
             />
             <div></div>
             <h3>Number of Likes vs Trending Date</h3>
@@ -180,7 +178,6 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.trend_date,
                   y: video.likes,
                 }))}
-                size = {genResults.length}
             />
           </>
         )}
@@ -206,7 +203,6 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.pub_date,
                   y: video.pub_to_trend,
                 }))}
-                size = {catResults.length}
               /><div></div>
             <h3>Number of Comments vs Trending Date</h3>
              <LineGraph
@@ -222,7 +218,6 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.trend_date,
                   y: video.comment_count,
                 }))}
-                size = {catResults.length}
                 /><div></div>
             <h3>Number of Likes vs Trending Date</h3>
             <LineGraph
@@ -239,7 +234,6 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                   x: video.trend_date,
                   y: video.likes,
                 }))}
-                size = {catResults.length}
             />
           </> 
         ) : (
@@ -266,9 +260,8 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                 .map((video) => ({
                   x: video.pub_date,
                   y: parseInt(video.pub_to_trend),
-                  custom: video.video_id.length < 1,
+                  custom: video?.video_id.length < 1,
                 }))}
-                size = {genResults.length}
                 color
             />
           </>

--- a/client/src/pages/Country/Country.tsx
+++ b/client/src/pages/Country/Country.tsx
@@ -266,7 +266,7 @@ export const Country: React.FC<CountryProps> = ({ country }) => {
                 .map((video) => ({
                   x: video.pub_date,
                   y: parseInt(video.pub_to_trend),
-                  custom: video.video_id.length < 1,
+                  custom: video?.video_id.length < 1,
                 }))}
                 size = {genResults.length}
                 color


### PR DESCRIPTION
## Overview
Added scaling of line graph size, which is dependent on how much data is being passed into a line graph. 

## Materials
- [Issue] https://github.com/JakinChan200/CS180_Roald/issues/63


## Pictures
![scaling](https://user-images.githubusercontent.com/43892704/168038805-665e80f6-bf9c-4bec-8e68-1d5f99d2ae1d.gif)

## Manual Testing Guide
- Perform npm install for dependencies in both server and client folders.
- Run npm start on both server and client folders to run the program.
- Go through any graphs between General, Query, and Experimental, and all line graphs should be properly scaled to each data size set.
